### PR TITLE
Add dataset links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ The datasets come from a variety of sources, as listed here:
 4. run `bash install.sh cu110`, replacing cu110 with your CUDA version (CUDA 11 -> cu110, CUDA 10.2 -> cu102, CUDA 10.1 -> cu101). We tested on Ubuntu 18.04, CUDA 11.0.
 
 
+## Dataset Preparation
+1. For large datasets (pokec, snap-patents, wiki), please download them manually using the links below and put them under  `data/` directory.
+* pokec data: [pokec.mat](https://drive.google.com/file/d/1ldh23TSY1PwXia6dU0MYcpyEgX-w3Hia/view?usp=sharing)
+* snap-patents data: [snap_patents.mat](https://drive.google.com/file/d/1dNs5E7BrWJbgcHeQ_zuy5Ozp2tRCWG0y/view?usp=sharing)
+* wiki data: [wiki_features.pt](https://drive.google.com/file/d/1ySNspxbK-snNoAZM7oxiWGvOnTRdSyEK/view?usp=sharing), [wiki_edges.pt](https://drive.google.com/file/d/14X7FlkjrlUgmnsYtPwdh-gGuFla4yb5u/view?usp=sharing)
+2. The rest data is alraedy in the codebase or will be downloaded automatically during the data loading.
+
 ## Running experiments
 
 1. Make sure a results folder exists in the root directory. 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ The datasets come from a variety of sources, as listed here:
 
 ## Dataset Preparation
 1. For large datasets (pokec, snap-patents, wiki), please download them manually using the links below and put them under  `data/` directory.
-* pokec data: [pokec.mat](https://drive.google.com/file/d/1ldh23TSY1PwXia6dU0MYcpyEgX-w3Hia/view?usp=sharing)
-* snap-patents data: [snap_patents.mat](https://drive.google.com/file/d/1dNs5E7BrWJbgcHeQ_zuy5Ozp2tRCWG0y/view?usp=sharing)
+* pokec data: [pokec.mat](https://drive.google.com/file/d/1dNs5E7BrWJbgcHeQ_zuy5Ozp2tRCWG0y/view?usp=sharing)
+* snap-patents data: [snap_patents.mat](https://drive.google.com/file/d/1ldh23TSY1PwXia6dU0MYcpyEgX-w3Hia/view?usp=sharing)
 * wiki data: [wiki_features.pt](https://drive.google.com/file/d/1ySNspxbK-snNoAZM7oxiWGvOnTRdSyEK/view?usp=sharing), [wiki_edges.pt](https://drive.google.com/file/d/14X7FlkjrlUgmnsYtPwdh-gGuFla4yb5u/view?usp=sharing)
 2. The rest data is alraedy in the codebase or will be downloaded automatically during the data loading.
 


### PR DESCRIPTION
This PR allows people to directly download large datasets using links in README, which is a temporary solution to #5.