### PR TITLE
switch to gdown to download large files

### DIFF
--- a/data_utils.py
+++ b/data_utils.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from scipy import sparse as sp
 from sklearn.metrics import roc_auc_score, f1_score
 from torch_sparse import SparseTensor
-from google_drive_downloader import GoogleDriveDownloader as gdd
+import gdown
 
 
 def rand_train_test_idx(label, train_prop=.5, valid_prop=.25, ignore_negative=True):
@@ -227,9 +227,9 @@ def load_fixed_splits(dataset, sub_dataset):
 
     if not os.path.exists(f'./data/splits/{name}-splits.npy'):
         assert dataset in splits_drive_url.keys()
-        gdd.download_file_from_google_drive(
-            file_id=splits_drive_url[dataset], \
-            dest_path=f'./data/splits/{name}-splits.npy', showsize=True) 
+        gdown.download(
+            id=splits_drive_url[dataset], \
+            output=f'./data/splits/{name}-splits.npy', quiet=False) 
     
     splits_lst = np.load(f'./data/splits/{name}-splits.npy', allow_pickle=True)
     for i in range(len(splits_lst)):

--- a/dataset.py
+++ b/dataset.py
@@ -7,7 +7,7 @@ import scipy.io
 import pickle
 import pandas as pd
 from sklearn.preprocessing import label_binarize
-from google_drive_downloader import GoogleDriveDownloader as gdd
+import gdown
 from os import path
 import os
 
@@ -234,9 +234,8 @@ def load_pokec_mat():
     """ requires pokec.mat
     """
     if not path.exists(f'{DATAPATH}pokec.mat'):
-        gdd.download_file_from_google_drive(
-            file_id=dataset_drive_url['pokec'], \
-            dest_path=f'{DATAPATH}pokec.mat', showsize=True)
+        gdown.download(id=dataset_drive_url['pokec'], \
+            output=f'{DATAPATH}pokec.mat', quiet=False)
 
     fulldata = scipy.io.loadmat(f'{DATAPATH}pokec.mat')
 
@@ -259,9 +258,8 @@ def load_snap_patents_mat(nclass=5):
     if not path.exists(f'{DATAPATH}snap_patents.mat'):
         p = dataset_drive_url['snap-patents']
         print(f"Snap patents url: {p}")
-        gdd.download_file_from_google_drive(
-            file_id=dataset_drive_url['snap-patents'], \
-            dest_path=f'{DATAPATH}snap_patents.mat', showsize=True)
+        gdown.download(id=dataset_drive_url['snap-patents'], \
+            output=f'{DATAPATH}snap_patents.mat', quiet=False)
 
     fulldata = scipy.io.loadmat(f'{DATAPATH}snap_patents.mat')
 
@@ -284,9 +282,8 @@ def load_snap_patents_mat(nclass=5):
 
 def load_yelpchi_dataset():
     if not path.exists(f'{DATAPATH}YelpChi.mat'):
-        gdd.download_file_from_google_drive(
-            file_id=dataset_drive_url['yelp-chi'], \
-            dest_path=f'{DATAPATH}YelpChi.mat', showsize=True)
+        gdown.download(id=dataset_drive_url['yelp-chi'], \
+            output=f'{DATAPATH}YelpChi.mat', quiet=False)
     fulldata = scipy.io.loadmat(f'{DATAPATH}YelpChi.mat')
     A = fulldata['homo']
     edge_index = np.array(A.nonzero())
@@ -378,13 +375,11 @@ def load_genius():
 
 def load_twitch_gamer_dataset(task="mature", normalize=True):
     if not path.exists(f'{DATAPATH}twitch-gamer_feat.csv'):
-        gdd.download_file_from_google_drive(
-            file_id=dataset_drive_url['twitch-gamer_feat'],
-            dest_path=f'{DATAPATH}twitch-gamer_feat.csv', showsize=True)
+        gdown.download(id=dataset_drive_url['twitch-gamer_feat'],
+            output=f'{DATAPATH}twitch-gamer_feat.csv', quiet=False)
     if not path.exists(f'{DATAPATH}twitch-gamer_edges.csv'):
-        gdd.download_file_from_google_drive(
-            file_id=dataset_drive_url['twitch-gamer_edges'],
-            dest_path=f'{DATAPATH}twitch-gamer_edges.csv', showsize=True)
+        gdown.download(id=dataset_drive_url['twitch-gamer_edges'],
+            output=f'{DATAPATH}twitch-gamer_edges.csv', quiet=False)
     
     edges = pd.read_csv(f'{DATAPATH}twitch-gamer_edges.csv')
     nodes = pd.read_csv(f'{DATAPATH}twitch-gamer_feat.csv')
@@ -407,19 +402,16 @@ def load_twitch_gamer_dataset(task="mature", normalize=True):
 def load_wiki():
 
     if not path.exists(f'{DATAPATH}wiki_features2M.pt'):
-        gdd.download_file_from_google_drive(
-            file_id=dataset_drive_url['wiki_features'], \
-            dest_path=f'{DATAPATH}wiki_features2M.pt', showsize=True)
+        gdown.download(id=dataset_drive_url['wiki_features'], \
+            output=f'{DATAPATH}wiki_features2M.pt', quiet=False)
     
     if not path.exists(f'{DATAPATH}wiki_edges2M.pt'):
-        gdd.download_file_from_google_drive(
-            file_id=dataset_drive_url['wiki_edges'], \
-            dest_path=f'{DATAPATH}wiki_edges2M.pt', showsize=True)
+        gdown.download(id=dataset_drive_url['wiki_edges'], \
+            output=f'{DATAPATH}wiki_edges2M.pt', quiet=False)
 
     if not path.exists(f'{DATAPATH}wiki_views2M.pt'):
-        gdd.download_file_from_google_drive(
-            file_id=dataset_drive_url['wiki_views'], \
-            dest_path=f'{DATAPATH}wiki_views2M.pt', showsize=True)
+        gdown.download(id=dataset_drive_url['wiki_views'], \
+            output=f'{DATAPATH}wiki_views2M.pt', quiet=False)
 
 
     dataset = NCDataset("wiki") 

--- a/install.sh
+++ b/install.sh
@@ -9,6 +9,7 @@ pip install ogb==1.2.4
 pip install flake8==3.8.4
 pip install Babel==2.9.0
 pip install flask==1.1.2
+pip install gdown==4.4.0
 
 
 pip install --no-index torch-scatter==2.0.5 -f https://pytorch-geometric.com/whl/torch-1.7.0+$CUDA.html


### PR DESCRIPTION
This PR switches `google_drive_downloader` to `gdown` for downloading data from Google Drive, aiming to solve the large files downloading issue of the python script mentioned in #4, #5, https://github.com/CUAI/Non-Homophily-Benchmarks/issues/2.